### PR TITLE
Disable Autostart of CoprHD Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Systemd is used inside of containers to start/stop CoprHD services.
 
 ### Howto
 
-- docker run --net=host -ti --privileged -v /data/coprhd1:/data:rw --name coprhd1 -h coprhd1 -d coprhd-controller:latest
+1- docker run --net=host -ti --privileged -v /data/coprhd1:/data:rw --name coprhd1 -h coprhd1 -d coprhd-controller:latest
+2- docker exec -ti coprhd1 /opt/storageos/bin/start
 
 ### Content and Scripting:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 # install CoprHD and do not start services
 # simplify CI/CD integration if services are not started, since network configuration might be done afterwards
-RUN DO_NOT_START="yes" rpm -iv /build/coprhd-controller/build/RPMS/x86_64/storageos-*.x86_64.rpm
+DO_NOT_START="yes" rpm -iv /build/coprhd-controller/build/RPMS/x86_64/storageos-*.x86_64.rpm
+
+systemctl disable storageos-installer.service
+systemctl disable boot-ovfenv.service
+systemctl disable nginx.service
+systemctl disable storageos-sys.service
+systemctl disable storageos-db.service
+systemctl disable storageos-geodb.service
+systemctl disable storageos-geo.service
+systemctl disable storageos-api.service
+systemctl disable storageos-auth.service
+systemctl disable storageos-controller.service
+systemctl disable storageos-coordinator.service
+systemctl disable storageos-portal.service
+systemctl disable storageos-sa.service


### PR DESCRIPTION
Required to make sure that services are started only after network
configuration customization.